### PR TITLE
Fix Color type

### DIFF
--- a/lib/src/chip_theme.dart
+++ b/lib/src/chip_theme.dart
@@ -58,10 +58,7 @@ class S2ChipTheme extends StatelessWidget {
     final Brightness brightness = Theme.of(context).brightness;
     final bool isDark = brightness == Brightness.dark;
 
-    final Color primaryColor = color ??
-        (!isDark
-            ? Theme.of(context).unselectedWidgetColor
-            : ChipTheme.of(context).backgroundColor);
+    final Color primaryColor = color ?? (!isDark ? Theme.of(context).unselectedWidgetColor : ChipTheme.of(context).backgroundColor!);
     final Color backgroundColor = raised == true
         ? primaryColor
         : outlined == true
@@ -82,24 +79,17 @@ class S2ChipTheme extends StatelessWidget {
             ? secondaryColor.withAlpha(foregroundAlpha)
             : primaryColor.withAlpha(foregroundAlpha);
 
-    final TextStyle defaultLabelStyle = ChipTheme.of(context).labelStyle;
-    final TextStyle primaryLabelStyle =
-        defaultLabelStyle.merge(labelStyle).copyWith(color: foregroundColor);
-    final TextStyle selectedLabelStyle = defaultLabelStyle
-        .merge(labelStyle)
-        .copyWith(
-            color: raised == true
-                ? Colors.white
-                : secondaryColor.withAlpha(foregroundAlpha));
+    final TextStyle? defaultLabelStyle = ChipTheme.of(context).labelStyle;
+    final TextStyle? primaryLabelStyle = defaultLabelStyle?.merge(labelStyle).copyWith(color: foregroundColor);
+    final TextStyle? selectedLabelStyle =
+        defaultLabelStyle?.merge(labelStyle).copyWith(color: raised == true ? Colors.white : secondaryColor.withAlpha(foregroundAlpha));
 
-    final ShapeBorder? chipShapeRaised =
-        raised == true ? StadiumBorder() : null;
+    final ShapeBorder? chipShapeRaised = raised == true ? StadiumBorder() : null;
     final ShapeBorder? chipShapeOutlined = outlined == true
         ? StadiumBorder(
             side: BorderSide(
-              color: selected == true
-                  ? secondaryColor.withOpacity(opacity ?? borderAlpha)
-                  : primaryColor.withOpacity(opacity ?? borderAlpha),
+              color:
+                  selected == true ? secondaryColor.withOpacity(opacity ?? borderAlpha) : primaryColor.withOpacity(opacity ?? borderAlpha),
             ),
           )
         : null;
@@ -115,10 +105,7 @@ class S2ChipTheme extends StatelessWidget {
         disabledColor: disabledColor,
         selectedColor: selectedColor,
         secondarySelectedColor: selectedColor,
-        shape: shape as OutlinedBorder? ??
-            chipShapeRaised as OutlinedBorder? ??
-            chipShapeOutlined as OutlinedBorder? ??
-            StadiumBorder(),
+        shape: shape as OutlinedBorder? ?? chipShapeRaised as OutlinedBorder? ?? chipShapeOutlined as OutlinedBorder? ?? StadiumBorder(),
         labelStyle: primaryLabelStyle,
         secondaryLabelStyle: selectedLabelStyle,
         elevation: raised == true ? elevation : 0,


### PR DESCRIPTION
Resolve issue for flutter version 2.10.0-0.3.pre. Nullpointer exception during compilation

```bash
Launching lib/main_dev.dart on Redmi Note 9S in debug mode...
lib/main_dev.dart:1
: Error: A value of type 'Color?' can't be assigned to a variable of type 'Color' because 'Color?' is nullable and 'Color' isn't.
../…/src/chip_theme.dart:61
 - 'Color' is from 'dart:ui'.
    final Color primaryColor = color ?? (!isDark ? Theme.of(context).unselectedWidgetColor : ChipTheme.of(context).backgroundColor);
                                     ^
: Error: A value of type 'TextStyle?' can't be assigned to a variable of type 'TextStyle' because 'TextStyle?' is nullable and 'TextStyle' isn't.
../…/src/chip_theme.dart:82
- 'TextStyle' is from 'package:flutter/src/painting/text_style.dart' ('../../../fvm/versions/beta/packages/flutter/lib/src/painting/text_style.dart').
package:flutter/…/painting/text_style.dart:1
    final TextStyle defaultLabelStyle = ChipTheme.of(context).labelStyle;
                                                              ^
2


FAILURE: Build failed with an exception.

* Where:
Script '/Users/brendan/fvm/versions/beta/packages/flutter_tools/gradle/flutter.gradle' line: 1102

* What went wrong:
Execution failed for task ':app:compileFlutterBuildDevDebug'.
> Process 'command '/Users/brendan/fvm/versions/beta/bin/flutter'' finished with non-zero exit value 1

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 1m 11s
Exception: Gradle task assembleDevDebug failed with exit code 1
Exited (sigterm)
```