### PR TITLE
support setting navigation style when showing full page selections

### DIFF
--- a/example/lib/features_multi/multi_page.dart
+++ b/example/lib/features_multi/multi_page.dart
@@ -1,5 +1,6 @@
-import 'package:flutter/material.dart';
 import 'package:awesome_select/awesome_select.dart';
+import 'package:flutter/material.dart';
+
 import '../choices.dart' as choices;
 
 class FeaturesMultiPage extends StatefulWidget {
@@ -29,6 +30,7 @@ class _FeaturesMultiPageState extends State<FeaturesMultiPage> {
           choiceItems: choices.months,
           modalType: S2ModalType.fullPage,
           onChange: (selected) => setState(() => _month = selected.value),
+          modalNavigatorType: S2ModalNavigatorType.cupertino,
         ),
         const SizedBox(height: 7),
       ],

--- a/example/lib/features_single/single_page.dart
+++ b/example/lib/features_single/single_page.dart
@@ -29,6 +29,7 @@ class _FeaturesSinglePageState extends State<FeaturesSinglePage> {
           selectedValue: _month,
           choiceItems: choices.months,
           onChange: (selected) => setState(() => _month = selected.value),
+          modalNavigatorType: S2ModalNavigatorType.cupertino,
         ),
         const SizedBox(height: 7),
       ],

--- a/lib/src/model/modal_config.dart
+++ b/lib/src/model/modal_config.dart
@@ -1,6 +1,8 @@
 import 'dart:ui';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
+
 import './modal_theme.dart';
 
 /// Target to open choices list
@@ -15,11 +17,22 @@ enum S2ModalType {
   bottomSheet,
 }
 
+enum S2ModalNavigatorType {
+  /// material, with zooming animation by default
+  material,
+
+  /// cupertino, with sliding animation by default
+  cupertino,
+}
+
 /// Modal configuration
 @immutable
 class S2ModalConfig with Diagnosticable {
   /// Modal type to display choices
   final S2ModalType type;
+
+  /// Modal navigator type: material or cupertino
+  final S2ModalNavigatorType navigatorType;
 
   /// Use different title with the trigger widget title
   final String? title;
@@ -82,6 +95,7 @@ class S2ModalConfig with Diagnosticable {
   /// Create modal configuration
   const S2ModalConfig({
     this.type = S2ModalType.fullPage,
+    this.navigatorType = S2ModalNavigatorType.material,
     this.title,
     this.useHeader = true,
     this.useConfirm = false,
@@ -138,10 +152,12 @@ class S2ModalConfig with Diagnosticable {
     bool? barrierDismissible,
     Color? barrierColor,
     S2ModalStyle? style,
+    S2ModalNavigatorType? navigatorType,
     S2ModalHeaderStyle? headerStyle,
   }) {
     return S2ModalConfig(
       type: type ?? this.type,
+      navigatorType: navigatorType ?? this.navigatorType,
       title: title ?? this.title,
       useHeader: useHeader ?? this.useHeader,
       useConfirm: useConfirm ?? this.useConfirm,
@@ -173,6 +189,7 @@ class S2ModalConfig with Diagnosticable {
 
     return copyWith(
       type: other.type,
+      navigatorType: other.navigatorType,
       title: other.title,
       useHeader: other.useHeader,
       useConfirm: other.useConfirm,

--- a/lib/src/widget/s2_state.dart
+++ b/lib/src/widget/s2_state.dart
@@ -1,5 +1,6 @@
 import 'package:awesome_select/awesome_select.dart';
 import 'package:collection/collection.dart' show ListEquality;
+import 'package:flutter/cupertino.dart' show CupertinoPageRoute;
 import 'package:flutter/material.dart';
 
 import '../choices_empty.dart';
@@ -698,7 +699,9 @@ abstract class S2State<T> extends State<SmartSelect<T>> {
       case S2ModalType.fullPage:
         confirmed = await (Navigator.push(
           context,
-          MaterialPageRoute(builder: (_) => modal),
+          modalConfig.navigatorType == S2ModalNavigatorType.material
+              ? MaterialPageRoute(builder: (_) => modal)
+              : CupertinoPageRoute(builder: (_) => modal),
         ));
         break;
       case S2ModalType.bottomSheet:

--- a/lib/src/widget/smart_select.dart
+++ b/lib/src/widget/smart_select.dart
@@ -385,6 +385,7 @@ class SmartSelect<T> extends StatefulWidget {
     S2ModalStyle? modalStyle,
     S2ModalHeaderStyle? modalHeaderStyle,
     S2ModalType? modalType,
+    S2ModalNavigatorType? modalNavigatorType,
     String? modalTitle,
     bool? modalConfirm,
     bool? modalHeader,
@@ -460,6 +461,7 @@ class SmartSelect<T> extends StatefulWidget {
           ),
       modalConfig: defaultModalConfig.merge(modalConfig).copyWith(
             type: modalType,
+            navigatorType: modalNavigatorType,
             title: modalTitle,
             filterHint: modalFilterHint,
             filterAuto: modalFilterAuto,
@@ -708,6 +710,7 @@ class SmartSelect<T> extends StatefulWidget {
     S2ModalStyle? modalStyle,
     S2ModalHeaderStyle? modalHeaderStyle,
     S2ModalType? modalType,
+    S2ModalNavigatorType? modalNavigatorType,
     String? modalTitle,
     bool? modalConfirm,
     bool? modalHeader,
@@ -783,6 +786,7 @@ class SmartSelect<T> extends StatefulWidget {
           ),
       modalConfig: defaultModalConfig.merge(modalConfig).copyWith(
             type: modalType,
+            navigatorType: modalNavigatorType,
             title: modalTitle,
             filterHint: modalFilterHint,
             filterAuto: modalFilterAuto,


### PR DESCRIPTION
Add two navigation style: cupertino (with sliding animation) and material (with zooming animation). By default, it performs material style of navigation. 

This setting works when modelType equals S2ModalType.fullPage, only

You can set navigation style like below:
        SmartSelect<String>.multiple(
          ...
          modalNavigatorType: S2ModalNavigatorType.cupertino,
       )